### PR TITLE
fix: change projects spaces

### DIFF
--- a/components/sections/homepage/Project/index.jsx
+++ b/components/sections/homepage/Project/index.jsx
@@ -6,10 +6,10 @@ import Projectcard from "./Projectcard";
 const Project = () => {
   return (
     <Wrapper>
-      <div className="pb-2.5 mt-11.25 md:mt-12 xl:mt-34.5 md:pb-6 xl:pb-24">
+      <div className="pb-2.5 mt-11.25 md:mt-12 xl:mt-36 md:pb-6 xl:pb-24">
         <Heading>Our Work</Heading>
       </div>
-      <div className="mt-6.25 md:mt-0 xl:-mx-20 -1.xl:-mx-11.5">
+      <div className="mt-6.25 md:mt-0 xl:-mx-20">
         {PROJECT.map((element, index) => (
           <Projectcard {...element} key={index} />
         ))}


### PR DESCRIPTION
## Describe your changes
We have changed the space between our work and who we are section to 144px 
## Issue ticket id and link
ID ->#001
Link ->[here](https://www.notion.so/apeunit/hero-section-Desktop-and-Mobile-margin-bottom-987a786aa7734276a22ded39b8b404ba)
## Tasks completed
- [x] The space between our work and who we section to 144px 
## How Has This Been Tested?
- [ ] npm install
- [ ] npm run dev

## Tasks not completed
- [ ] the underlined words in the paragraph should not break on mobile and tablet 
## Notes (if needed)
For the underlined words they break even on mobile, kindly do a re-check on the Figma design
## Screenshots (if needed)