### PR TITLE
fix: spaces between title and description

### DIFF
--- a/components/sections/homepage/About/index.jsx
+++ b/components/sections/homepage/About/index.jsx
@@ -6,7 +6,7 @@ const About = () => {
     <Wrapper>
       <div className="mt-23.75 md:mt-24.5 xl:mt-45.75">
         <Heading>Who we are</Heading>
-        <div className="lg:mt-13.25 pb-5 md:py-8.75 xl:py-4.5 text-2xl font-normal text-secondary-400 md:text-9.5 md:font-medium leading-25 -tracking-stretch mt-5">
+        <div className="lg:mt-13.25 xl:mt-0 pb-5 md:py-8.75 xl:py-4.5 text-2xl font-normal text-secondary-400 md:text-9.5 md:font-medium leading-25 -tracking-stretch mt-5">
           <p className="md:pb-6">
             Ape Unit was founded in 2010 in Berlin. Since 2017 Ape Unit{"'"}s
             Unit 8 has been working in the field of blockchain technology. We


### PR DESCRIPTION
## Describe your changes
Changing the title and description space into 18px
## Issue ticket id and link
ID ->#002
Link ->[here](https://www.notion.so/apeunit/who-we-are-section-Desktop-spacing-03ac301fb39d42b8aee3516354e17934)
## Tasks completed
- [x] Space between title  and description 
## How Has This Been Tested?
- [x] npm install
- [x] npm run dev
## Tasks not completed
## Notes (if needed)
We are sticking with the 18px space between the title and description on Figma, as changing it to 115px would not be consistent with our design.
## Screenshots (if needed)
