### PR TITLE
fix: remove the hero text padding on small screens

### DIFF
--- a/components/sections/homepage/Hero/index.jsx
+++ b/components/sections/homepage/Hero/index.jsx
@@ -9,7 +9,7 @@ const Hero = () => {
           Unit A
         </h1>
       </header>
-      <div className="xl:px-20 sm:px-11.5">
+      <div className="xl:px-20">
         <div className="text-white relative mt-31.25 xl:mt-41.75 leading-normal -tracking-stretch">
           <Image
             src="/images/shape-2.webp"


### PR DESCRIPTION
## Describe your changes

Removed the hero text padding x for all small screens

## Issue ticket id and link

ID -> #004

Link -> https://www.notion.so/apeunit/Hero-Section-Tablet-Alignment-c4b00d2d45e74bc7af10d028a1545c0c

## Tasks completed

- [ ] Removed the padding x for small breakpoints

## How Has This Been Tested?

- [x] npm run dev

## Tasks not completed

- None

## Notes (if needed)

## Screenshots (if needed)
