### PR TITLE
fix: change contact button target

### DIFF
--- a/components/sections/homepage/About/index.jsx
+++ b/components/sections/homepage/About/index.jsx
@@ -20,7 +20,7 @@ const About = () => {
             work in blockchain technology.
           </p>
         </div>
-        <Button link="mailto:u2467@apeunit.com">Contact us</Button>
+        <Button link="mailto:u2467@apeunit.com" target="_blank">Contact us</Button>
       </div>
     </Wrapper>
   );


### PR DESCRIPTION
## Describe your changes

Added the `_blank` target to the contact us  button so that the mailbox can be opened in another tab

## Issue ticket id and link

ID -> #006

Link -> [here](https://www.notion.so/apeunit/Contact-Us-Section-All-Redirect-124cab069c6a44b7a26270c6d4acca85)

## Tasks completed

- [x] I have changed the target of the contact us link

## How Has This Been Tested?

This has been tested in the browser bu running the following command:

 ```
npm run dev
```

## Tasks not completed

None
