### PR TITLE
fix: button responsiveness

### DIFF
--- a/components/ui/Button.jsx
+++ b/components/ui/Button.jsx
@@ -5,7 +5,7 @@ const Button = ({ children, link = "#", target, size = "normal" }) => {
   const buttonStyle = classNames(
     "bg-white text-black -tracking-stretch flex w-fit px-8.75 lg:px-12 gap-6 group",
     {
-      "py-4 text-3xl leading-11 rounded-5xl": size === "large",
+      "py-4 text-md sm:text-3xl leading-11 rounded-5xl": size === "large",
       "py-3 leading-9 text-2xl rounded-4xl": size !== "large",
     }
   );


### PR DESCRIPTION
## Describe your changes
the title of the button aligns with the arrow on some row
## Issue ticket id and link
ID ->#008
Link ->[here](https://www.notion.so/apeunit/Schedule-a-Call-Section-Mobile-button-breakage-5851a98e153643578dc820e3df3aaa5f)
## Tasks completed
- [x] the title of the button aligns with the arrow on some row
## How Has This Been Tested?
- [ ] npm install
- [ ] npm run dev
## Tasks not completed
## Notes (if needed)
here on this issue, we change the only font size to make responsiveness to all breakpoints 
## Screenshots (if needed)