### PR TITLE
fix: change services alignement and spaces

### DIFF
--- a/components/sections/homepage/Services/ServiceItem/index.jsx
+++ b/components/sections/homepage/Services/ServiceItem/index.jsx
@@ -3,12 +3,12 @@ import classNames from 'classnames';
 const ServiceItem = ({ title, description, reverse, index, fadeDir, icon, width, height }) => {
   
   const serviceStyle = classNames('flex flex-col-reverse gap-8 justify-between leading-normal', {
-    'lg:flex-row-reverse': reverse,
-    'lg:flex-row': !reverse,
+    'sm:flex-row-reverse': reverse,
+    'sm:flex-row': !reverse,
   });
 
   const imageStyle = classNames(
-    'object-contain w-69.5 m-0 h-44.75 md:w-74.5 md:h-44.75 md:m-auto xl:h-auto xl:w-auto',
+    'object-contain object-left overflow-hidden w-69.5 m-0 h-44.75 md:w-74.5 md:h-44.75 md:m-auto xl:h-auto xl:w-auto',
     { 'md:h-28.75': index === 2 }
   );
 


### PR DESCRIPTION
## Describe your changes

Aligned the service's description and image on the same line on all tablet breakpoints, and positioned the image on the left side of its container

## Issue ticket id and link

ID -> #007

Link -> [here](https://www.notion.so/apeunit/What-We-Do-Section-Tablet-and-Mobile-Alignment-fa2bcb0eabd940d184217bebba002bb6)

## Tasks completed

- [x] I have applied the same flex direction for desktop on all tablet breakpoints
- [x] I positioned the service image in the left side of its container

## How Has This Been Tested?

This change has been tested in the browser by running the development server with this command:

```
npm run dev
```

## Tasks not completed

None
