### PR TITLE
fix: update projects title padding bottom

### DIFF
--- a/components/sections/homepage/Project/index.jsx
+++ b/components/sections/homepage/Project/index.jsx
@@ -6,7 +6,7 @@ import Projectcard from "./Projectcard";
 const Project = () => {
   return (
     <Wrapper>
-      <div className="pb-2.5 mt-11.25 md:mt-12 xl:mt-36 md:pb-6 xl:pb-24">
+      <div className="pb-2.5 mt-11.25 md:mt-12 xl:mt-36 md:pb-6 xl:pb-28.75">
         <Heading>Our Work</Heading>
       </div>
       <div className="mt-6.25 lg:px-11.5 1.1xl:px-0 md:mt-0 xl:-mx-20">


### PR DESCRIPTION
## Describe your changes

Changed the spacing between the projects section's title and cards

## Issue ticket id and link

ID -> #011

Link -> [here](https://www.notion.so/apeunit/Our-Work-section-Desktop-spacing-5643737c50cd41d79c7171d29c159395)

## Tasks completed

- [x] I have updated the padding bottom of the title container

## How Has This Been Tested?

This change has been tested in the browser after running the development server with the command:

```
npm run dev
```

## Tasks not completed

- None
