### PR TITLE
fix: logo alignment on tablet breakpoint

### DIFF
--- a/components/sections/homepage/Partners/index.jsx
+++ b/components/sections/homepage/Partners/index.jsx
@@ -12,7 +12,7 @@ const Partners = () => {
         <div className="mt-3 lg:mt-5.5 text-2xl text-secondary-400 text-center leading-normal">
           We partner with the leading brands
         </div>
-        <div className="mt-3.25 md:w-4/5 lg:w-4/5 justify-center flex gap-y-4 gap-x-6 xl:gap-x-6 flex-wrap">
+        <div className="mt-3.25 md:w-4/5 lg:w-4/5 justify-center flex gap-y-4 gap-x-6 xl:gap-x-8 flex-wrap">
           {PARTNERS.map(({ image, name, width, height, link }, index) => (
             <div key={index}>
               <Link href={link} target="_blank">

--- a/components/sections/homepage/Partners/index.jsx
+++ b/components/sections/homepage/Partners/index.jsx
@@ -12,7 +12,7 @@ const Partners = () => {
         <div className="mt-3 lg:mt-5.5 text-2xl text-secondary-400 text-center leading-normal">
           We partner with the leading brands
         </div>
-        <div className="mt-3.25 xl:w-4/5 justify-center flex gap-y-4 gap-x-1.5 sm:gap-x-6 xl:gap-x-6 flex-wrap sm:justify-center">
+        <div className="mt-3.25 md:w-4/5 lg:w-4/5 justify-center flex gap-y-4 gap-x-6 xl:gap-x-6 flex-wrap">
           {PARTNERS.map(({ image, name, width, height, link }, index) => (
             <div key={index}>
               <Link href={link} target="_blank">
@@ -21,7 +21,7 @@ const Partners = () => {
                   alt={name}
                   width={width}
                   height={height}
-                  className="h-9 w-18.75 object-contain xl:w-auto xl:h-auto xl:min-w-min xl:object-cover"
+                  className="xl:object-cover"
                 />
               </Link>
             </div>


### PR DESCRIPTION
## Describe your changes
On the tablet breakpoint, the logo was on some lines but right now the logo is on the same line
## Issue ticket id and link
ID ->#010
Link ->[here](https://www.notion.so/apeunit/Partners-Section-Desktop-spacing-0031882195cf4ad1a56d3209add2054b)
## Tasks completed
- [x] Alignment of the logo in different lines on the tablet breakpoint
## How Has This Been Tested?
- [ ] npm install
- [ ] npm run dev
## Tasks not completed
## Notes (if needed)
## Screenshots (if needed)
