### PR TITLE
Fix: service description font line-height and letter-spacing

### DIFF
--- a/components/sections/homepage/Services/ServiceItem/index.jsx
+++ b/components/sections/homepage/Services/ServiceItem/index.jsx
@@ -15,7 +15,7 @@ const ServiceItem = ({ title, description, reverse, index, fadeDir, icon, width,
     <div className={serviceStyle}>
       <div className='flex flex-col gap-4 md:w-2/3 xl:max-w-1/2'>
         <div className='text-5.75 md:text-9.5 -tracking-stretch text-white leading-9 md:leading-12.25'>{title}</div>
-        <div className='text-lg md:text-2xl md:leading-7.5 text-secondary-400'>{description}</div>
+        <div className='text-lg -tracking-stretch leading-6.75 md:text-2xl md:leading-7.5 lg:leading-7.5 text-secondary-400'>{description}</div>
       </div>
       <Image src={icon} alt='icon' width={width} height={height} className={imageStyle} data-aos={`fade-${fadeDir}`} />
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -48,6 +48,7 @@ module.exports = {
         "5xl": "2.8125rem",
       },
       lineHeight: {
+        6.75: "1.6875rem",
         7.5: "1.875rem",
         9.5: "2.375rem",
         11: "2.8125rem",


### PR DESCRIPTION
## Describe your changes

Changed the service item's description line height and letter-spacing

## Issue ticket id and link

ID -> 036

Link -> https://www.notion.so/apeunit/What-We-Do-Mobile-21d25e0c18c849febc377a4128dd43db?pvs=4

## Tasks completed

- [x] I have performed a self-review of my code
- [x] I have added a new value in the tailwind config

## How Has This Been Tested?

This change has been tested in the browser after running the development server with the command below:
```
npm run dev
```
