### PR TITLE
Fix: changed patrners paragraph margin

### DIFF
--- a/components/sections/homepage/Partners/index.jsx
+++ b/components/sections/homepage/Partners/index.jsx
@@ -9,10 +9,10 @@ const Partners = () => {
     <Wrapper>
       <div className="flex flex-col items-center mt-12 md:mt-33">
         <Heading>Partners</Heading>
-        <div className="mt-3 md:mt-5.5 text-lg md:text-2xl text-secondary-400 text-center md:leading-7.5">
+        <div className="text-lg md:text-2xl text-secondary-400 text-center md:leading-7.5">
           We partner with the leading brands
         </div>
-        <div className="mt-3.25 md:w-7/10 items-center justify-center flex gap-y-4 gap-x-6 flex-wrap">
+        <div className="mt-6 lg:mt-5 md:w-7/10 items-center justify-center flex gap-y-4 gap-x-6 flex-wrap">
           {PARTNERS.map(({ image, name, width, height, link }, index) => (
             <div key={index}>
               <Link href={link} target="_blank">


### PR DESCRIPTION
## Describe your changes

Fix the margin between the partner's paragraph surrounding content

## Issue ticket id and link

ID -> 040

Link -> https://www.notion.so/apeunit/Partners-Section-Mobile-Desktop-Spacing-045cb0c5b18d49f89afc516106c13bf7?pvs=4

## Tasks completed

- [x] I have performed a self-review of my code
- [x] I have removed the margin between the section's title and the paragraph
- [x] I have changed the margin size between the paragraph and the logos

## How Has This Been Tested?

This change has been tested in the browser by first, installing all dependencies with the cmd:
```
npm install
```
Then, running the dev server with
```
npm run dev
```
