### PR TITLE
fix: fixing marging bottom and letter spacing on footer section

### DIFF
--- a/components/layouts/Footer.jsx
+++ b/components/layouts/Footer.jsx
@@ -4,7 +4,7 @@ import Wrapper from "./Wrapper";
 const Footer = () => {
   return (
     <Wrapper size="small">
-      <div className="flex flex-col gap-13 md:gap-0 md:flex-row justify-between md:mt-42 mt-10.2 md:mb-26 mb-8 md:text-7.5 text-xl leading-7.5 md:leading-9.5">
+      <div className="flex flex-col gap-13 md:gap-0 md:flex-row justify-between md:mt-42 mt-10.2 md:mb-31.25 mb-8 md:text-7.5 text-xl leading-7.5 md:leading-9.5 -tracking-stretch">
         <ul className="space-y-2.5">
           <li>Ape Unit GmbH</li>
           <li>Waldemarstraße 38,</li>


### PR DESCRIPTION
## Describe your changes
Fixing the margin-bottom of the footer and fixing also the letter spacing on both desktop and mobile

## Issue ticket id and link

ID -> #041

Link [->here](https://www.notion.so/apeunit/Footer-Mobile-Desktop-Spacing-ca909d44a29749c08f5c658fb5ee4cad?pvs=4)

## Tasks completed

- [x] Fixing the margin-bottom of the footer
- [x] Fixing the letter spacing on the footer both on desktop and mobile

## How Has This Been Tested?

- [x] npm install
- [x] npm run dev 

## Tasks not completed

None

## Notes (if needed)

None

## Screenshots (if needed)

None