### PR TITLE
fix: line height on contact us

### DIFF
--- a/components/sections/homepage/CallToAction/index.jsx
+++ b/components/sections/homepage/CallToAction/index.jsx
@@ -5,10 +5,10 @@ const CallToAction = () => {
   return (
     <Wrapper size="small">
       <div className="h-max bg-primary-800 rounded-4xl lg:py-16 py-5.5 px-5.5 flex flex-col items-center mt-12 md:mt-32">
-        <h1 className="md:text-11.75 text-6.5 font-normal text-center leading-10 md:leading-14.75 -tracking-stretcher">
+        <h1 className="md:text-11.75 text-6.5 font-normal text-center leading-9.75 md:leading-14.75 -tracking-stretcher">
           Ready to talk about your project?
         </h1>
-        <p className="text-center mx-auto text-lg md:text-2xl  md:leading-7.5 text-white opacity-70 xl:w-4/5 pt-3">
+        <p className="text-center mx-auto text-lg md:text-2xl leading-6.75 md:leading-7.5 text-white opacity-70 xl:w-4/5 pt-3">
           Are you looking for a consultancy partnership to address your
           blockchain challenges? We’d love to hear from you. Let’s build
           something amazing together.


### PR DESCRIPTION
## Describe your changes
I have changed the line height of the title and paragraph in the contact us section 
## Issue ticket id and link
ID ->#42

Link ->[here](https://www.notion.so/apeunit/248d49c9575540fa989b91fc92eb14d1?v=53f93136c76f49638a283864ecbef014&p=0910e5ad6c6a4abeaf9a5ffe43655d59&pm=s)
## Tasks completed
- [x] Applying the line height of 39px on the title 
- [x] Applying the line height of 27px on the paragraph 
## How Has This Been Tested?
- [ ] npm install
- [ ] npm run dev
## Tasks not completed
## Notes (if needed)
## Screenshots (if needed)
